### PR TITLE
only display sections if there is at least one item to display below them

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7329,9 +7329,14 @@ async function addResults(results, summary, displayOptions) {
   }
 
   for (resultType of getResultTypesFromDisplayOptions(displayOptions)) {
+    const results_for_type = results[resultType];
+    if (!results_for_type.length) {
+      continue;
+    }
+
     gha.summary.addHeading(resultType, 2);
 
-    for (const result of results[resultType]) {
+    for (const result of results_for_type) {
       // FIXME: check if message is undefined otherwise, just post this as regular line
       addDetailsWithCodeBlock(
         gha.summary,

--- a/src/results.js
+++ b/src/results.js
@@ -108,9 +108,14 @@ async function addResults(results, summary, displayOptions) {
   }
 
   for (resultType of getResultTypesFromDisplayOptions(displayOptions)) {
+    const results_for_type = results[resultType];
+    if (!results_for_type.length) {
+      continue;
+    }
+
     gha.summary.addHeading(resultType, 2);
 
-    for (const result of results[resultType]) {
+    for (const result of results_for_type) {
       // FIXME: check if message is undefined otherwise, just post this as regular line
       addDetailsWithCodeBlock(
         gha.summary,


### PR DESCRIPTION
Fixes #14. @shaperilio I unfortunately don't have time to test this properly. Could you run your workflow with

```yaml
- name: Surface failing tests
  uses: pmeier/pytest-results-action@empty-sections
```

and see if it does indeed work correctly? With your confirmation, I'll  release `0.5.0`.